### PR TITLE
投稿画面/マイルーム画面 を微調整

### DIFF
--- a/app/controllers/clips_controller.rb
+++ b/app/controllers/clips_controller.rb
@@ -4,7 +4,11 @@ class ClipsController < ApplicationController
   end
 
   def new
-    @clip = Clip.new
+    if user_signed_in?
+      @clip = Clip.new
+    else
+      redirect_to new_user_registration_path, alert: 'ご利用には無料登録が必要です。'
+    end
   end
 
   def create

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -394,7 +394,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <%= link_to "写真をすべて見る", user_path(@user.id), class: "all-photo" %>
     </div>
       <ul>
-        <% @user.clips.first(12).reverse_each do |clip| %>
+        <% @user.clips.first(14).reverse_each do |clip| %>
           <li>
             <%= link_to image_tag(clip.image), clip_path(clip) %>
           </li>


### PR DESCRIPTION
# WHAT
・ログインしてないユーザーが直接投稿画面を開けないように修正
・マイルームの全ての写真12→14に修正

# WHY
・ログインしてないユーザーが投稿出来たらおかしい＆投稿するとuser.idなくてエラーになる
・とりあえず本物も14枚表示されてるので。ゆくゆくJSでスクロール表示されるようにしたい内容。